### PR TITLE
feat(javascript): add composite action for pnpm

### DIFF
--- a/javascript/pnpm-install/action.yml
+++ b/javascript/pnpm-install/action.yml
@@ -1,0 +1,25 @@
+name: Install pnpm dependencies
+description: Install dependencies using pnpm
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Set up pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This only handles the part of setting up pnpm with the cache.
Makes it easy since we don't need any in or outputs.
